### PR TITLE
Performance improvements

### DIFF
--- a/ExPerfAnalyzer-beta2.ps1
+++ b/ExPerfAnalyzer-beta2.ps1
@@ -727,24 +727,6 @@ param(
 		return $serverPerfObject
 	}
 
-	Function Add-ServerPerformanceObject_ValueTemp {
-	[CmdletBinding()]
-	[OutputType([System.Collections.Generic.List[System.Object]])]
-	param(
-		[Parameter(Mandatory=$true)][array]$CounterSampleData
-	)
-		Write-Verbose("[{0}] : Calling Add-ServerPerformanceObject_Value" -f [system.dateTime]::Now)
-		$values = New-Object System.Collections.Generic.List[System.Object]
-		$measure_loop = Measure-Command {
-			foreach($csd in $CounterSampleData)
-			{
-				$values.Add($csd)
-			}
-		}
-		Write-Verbose("[{0}] : Took {1} seconds to process {2} items" -f [datetime]::Now, $measure_loop.Seconds, $CounterSampleData.Count)
-		return $values
-	}
-
 	Function Add-ServerPerformanceObject_Value {
 	[CmdletBinding()]
 	[OutputType([System.Collections.Generic.List[System.Object]])]
@@ -776,7 +758,7 @@ param(
 	{
 		$counterNameObj = Get-FullCounterNameObject -PerformanceCounterSample $gPath.Group[0]
 		$counterDataObj = Build-ServerPerformanceObject_CounterData -CounterNameObject $counterNameObj 
-		$counterDataObj | Add-Member -Name RawData -MemberType NoteProperty -Value  ((Add-ServerPerformanceObject_ValueTemp -CounterSampleData ($gPath.Group | select -Skip 1)))
+		$counterDataObj | Add-Member -Name RawData -MemberType NoteProperty -Value $gPath.Group
 		$counterDataObj.CounterType = $counterDataObj.RawData[0].CounterType
 		$tMasterObject.Add($counterDataObj)
 	}
@@ -851,7 +833,7 @@ param(
 		{
 			foreach($counterObj in $svrObj.CounterData)
 			{
-				$measured = $counterObj.RawData | Select-Object -Skip 1 | Measure-Object -Property CookedValue -Maximum -Minimum -Average
+				$measured = $counterObj.RawData | Measure-Object -Property CookedValue -Maximum -Minimum -Average
 
 				$counterObj.QuickSummaryStats.Min = $measured.Minimum
 				$counterObj.QuickSummaryStats.Max = $measured.Maximum


### PR DESCRIPTION
Two small changes that reduce run time by about 40%. See the commit message for full details.

Before:

```
Analysis Stats
================
Report Generated by      : ExPerfAnalyzer.ps1 v1.0
Written by               : Matthew Huynh (mahuynh@microsoft.com) & David Paulson (dpaul@microsoft.com
Generated On             : 7/22/2017 1:32 AM
Total Counters Processed : 517
Total Samples            : 744,480
Total Processing Time    : 97.8s
Samples Processed/sec    : 7,613.32510s
Proc. Time Per Sample    : 0.00013s

Script took 97.8082526 seconds to complete
[7/22/2017 1:32:49 AM] : Get-PerformanceDataFromFileLocal  took 20.4924413 seconds to complete.
[7/22/2017 1:32:49 AM] : Add-CountersToAnalyzeToObject took 1.382094 seconds to complete.
[7/22/2017 1:32:49 AM] : Analyze-DataOfObject took 36.6035793 seconds to complete
[7/22/2017 1:32:49 AM] : Output-QuickSummaryDetails took 0.620003 seconds to complete
[7/22/2017 1:32:49 AM] : Convert-PerformanceCounterSampleObjectToServerPerformanceObject took 28.7390261 seconds to complete
[7/22/2017 1:32:49 AM] : Convert-PerformanceCounterSampleObjectToServerPerformanceObject Total Group path took 28.5917558 seconds to complete.
[7/22/2017 1:32:49 AM] : Convert-PerformanceCounterSampleObjectToServerPerformanceObject build server object took 0.1383298 seconds to complete.
[7/22/2017 1:32:49 AM] : Convert-PerformanceCounterSampleObjectToServerPerformanceObject grouping objects for server build took 0.0450136 seconds to complete
[7/22/2017 1:32:49 AM] : Convert-PerformanceCounterSampleObjectToServerPerformanceObject build server time finder took 0.06546 seconds to complete.
```

After:

```
Analysis Stats
================
Report Generated by      : ExPerfAnalyzer.ps1 v1.0
Written by               : Matthew Huynh (mahuynh@microsoft.com) & David Paulson (dpaul@microsoft.com
Generated On             : 7/22/2017 1:30 AM
Total Counters Processed : 517
Total Samples            : 744,997
Total Processing Time    : 60.6s
Samples Processed/sec    : 12,292.49920s
Proc. Time Per Sample    : 0.00008s

Script took 60.6244831 seconds to complete
[7/22/2017 1:30:57 AM] : Get-PerformanceDataFromFileLocal  took 20.3648267 seconds to complete.
[7/22/2017 1:30:57 AM] : Add-CountersToAnalyzeToObject took 0.6090205 seconds to complete.
[7/22/2017 1:30:57 AM] : Analyze-DataOfObject took 25.6023905 seconds to complete
[7/22/2017 1:30:57 AM] : Output-QuickSummaryDetails took 0.571919 seconds to complete
[7/22/2017 1:30:57 AM] : Convert-PerformanceCounterSampleObjectToServerPerformanceObject took 3.8056277 seconds to complete
[7/22/2017 1:30:57 AM] : Convert-PerformanceCounterSampleObjectToServerPerformanceObject Total Group path took 3.6218747 seconds to complete.
[7/22/2017 1:30:57 AM] : Convert-PerformanceCounterSampleObjectToServerPerformanceObject build server object took 0.1757835 seconds to complete.
[7/22/2017 1:30:57 AM] : Convert-PerformanceCounterSampleObjectToServerPerformanceObject grouping objects for server build took 0.0143237 seconds to complete
[7/22/2017 1:30:57 AM] : Convert-PerformanceCounterSampleObjectToServerPerformanceObject build server time finder took 0.0806877 seconds to complete.
```