### PR TITLE
Bilong perf tuning 3

### DIFF
--- a/ExPerfAnalyzer-beta2.ps1
+++ b/ExPerfAnalyzer-beta2.ps1
@@ -813,10 +813,18 @@ param(
 		{
 			foreach($counterObj in $svrObj.CounterData)
 			{
-				$measured = $counterObj.RawData | Measure-Object -Property CookedValue -Maximum -Minimum -Average
+				# $measured = $counterObj.RawData | Measure-Object -Property CookedValue -Maximum -Minimum -Average
 
-				$counterObj.QuickSummaryStats.Min = $measured.Minimum
-				$counterObj.QuickSummaryStats.Max = $measured.Maximum
+				$min = [Int64]::MaxValue;
+				$max = [Int64]::MinValue;
+				foreach ($sample in $counterObj.RawData) 
+				{
+					if ($sample.CookedValue -lt $min) { $min = $sample.CookedValue; }
+					if ($sample.CookedValue -gt $max) { $max = $sample.CookedValue; }
+				}
+
+				$counterObj.QuickSummaryStats.Min = $min
+				$counterObj.QuickSummaryStats.Max = $max
 				$counterObj.QuickSummaryStats.StartTime = $counterObj.RawData[0].TimeStamp
 				$counterObj.QuickSummaryStats.EndTime = $counterObj.RawData[-1].TimeStamp
 				$counterObj.QuickSummaryStats.Duration = New-TimeSpan $($counterObj.QuickSummaryStats.StartTime) $($counterObj.QuickSummaryStats.EndTime)
@@ -832,12 +840,12 @@ param(
 					$numOpsDif = $counterObj.RawData[-1].SecondValue - $counterObj.RawData[0].SecondValue 
 					if($frequency -ne 0 -and $numTicksDiff -ne 0 -and $numOpsDif -ne 0)
 					{
-						$counterObj.QuickSummaryStats.Avg = (($numTicksDiff / $frequency) / $numOpsDif)
+						$counterObj.QuickSummaryStats.Avg = ($counterObj.RawData | Measure-Object -Property CookedValue -Average).Average
 					}
 				}
 				else
 				{
-					$counterObj.QuickSummaryStats.Avg = $measured.Average
+					$counterObj.QuickSummaryStats.Avg = $sum / $counterObj.RawData.Count;
 				}
 
 			}

--- a/ExPerfAnalyzer-beta2.ps1
+++ b/ExPerfAnalyzer-beta2.ps1
@@ -723,30 +723,6 @@ param(
 		return $serverPerfObject
 	}
 
-	Function Add-ServerPerformanceObject_Value {
-	[CmdletBinding()]
-	[OutputType([System.Collections.Generic.List[System.Object]])]
-	param(
-		[Parameter(Mandatory=$true)][array]$CounterSampleData
-	)
-		Write-Verbose("[{0}] : Calling Add-ServerPerformanceObject_Value" -f [system.dateTime]::Now)
-		$values = New-Object System.Collections.Generic.List[System.Object]
-		$measure_loop = Measure-Command {
-			foreach($csd in $CounterSampleData)
-			{
-				$tRawData = New-Object -TypeName PerformanceHealth.RawDataObject
-				$tRawData.TimeStamp = $csd.TimeStamp 
-				$tRawData.CookedValue = $csd.CookedValue
-				$tRawData | Add-Member -Name TimeBase -MemberType NoteProperty -Value $csd.TimeBase
-				$tRawData | Add-Member -Name RawValue -MemberType NoteProperty -Value $csd.RawValue 
-				$tRawData | Add-Member -Name SecondValue -MemberType NoteProperty -Value $csd.SecondValue 
-				$values.Add($tRawData)
-			}
-		}
-		Write-Verbose("[{0}] : Took {1} seconds to process {2} items" -f [datetime]::Now, $measure_loop.Seconds, $CounterSampleData.Count)
-		return $values
-	}
-
 	$Script:convertMeasureTime = Measure-Command{
 	$tMasterObject = New-Object System.Collections.Generic.List[System.Object]
 		$Script:convert_Total_PathGroup = Measure-Command{


### PR DESCRIPTION
Avoiding Measure except for the Average shaves another 4 seconds off the
average run time. We could manually calculate the Average too, but that
gets tricky if you want to avoid overflows.